### PR TITLE
Improve BluetoothSerialSocket robustness

### DIFF
--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/bluetooth/BluetoothSerialSocket.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/bluetooth/BluetoothSerialSocket.java
@@ -110,8 +110,10 @@ private static final String TAG = BluetoothSerialSocket.class.getSimpleName();
             //noinspection InfiniteLoopStatement
             while (true) {
                 len = socket.getInputStream().read(buffer);
-                if (len == -1) {
-                    throw new IOException("Bluetooth input stream closed");
+if (len == -1) {
+                    IOException e = new IOException("Bluetooth input stream closed");
+                    Log.e(TAG, "Bluetooth input stream closed", e);
+                    throw e;
                 }
                 byte[] data = Arrays.copyOf(buffer, len);
                 if (listener != null)

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/bluetooth/BluetoothSerialSocket.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/bluetooth/BluetoothSerialSocket.java
@@ -68,7 +68,7 @@ public class BluetoothSerialSocket implements Runnable {
             try {
                 socket.close();
             } catch (Exception e) {
-                Log.e(TAG, "Error closing bluetooth socket", e);
+private static final String TAG = BluetoothSerialSocket.class.getSimpleName();
             }
             socket = null;
         }

--- a/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/bluetooth/BluetoothSerialSocket.java
+++ b/ft8cn/app/src/main/java/com/bg7yoz/ft8cn/bluetooth/BluetoothSerialSocket.java
@@ -64,16 +64,18 @@ public class BluetoothSerialSocket implements Runnable {
     void disconnect() {
         listener = null; // ignore remaining data and errors
         // connected = false; // run loop will reset connected
-        if(socket != null) {
+        if (socket != null) {
             try {
                 socket.close();
-            } catch (Exception ignored) {
+            } catch (Exception e) {
+                Log.e(TAG, "Error closing bluetooth socket", e);
             }
             socket = null;
         }
         try {
             context.unregisterReceiver(disconnectBroadcastReceiver);
-        } catch (Exception ignored) {
+        } catch (Exception e) {
+            Log.e(TAG, "Error unregistering disconnect receiver", e);
         }
     }
 
@@ -108,8 +110,11 @@ public class BluetoothSerialSocket implements Runnable {
             //noinspection InfiniteLoopStatement
             while (true) {
                 len = socket.getInputStream().read(buffer);
+                if (len == -1) {
+                    throw new IOException("Bluetooth input stream closed");
+                }
                 byte[] data = Arrays.copyOf(buffer, len);
-                if(listener != null)
+                if (listener != null)
                     listener.onSerialRead(data);
             }
         } catch (Exception e) {


### PR DESCRIPTION
## Summary
- handle EOF properly in BluetoothSerialSocket
- log disconnect cleanup errors for easier debugging

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6847c00c83988320a38c92077b592b12